### PR TITLE
Added Twintag to the list of adopters

### DIFF
--- a/ADOPTERS.MD
+++ b/ADOPTERS.MD
@@ -5,3 +5,4 @@
 Below is a list of projects that have adopted OpenFGA. If you have been using OpenFGA and your name is not on this list, send us a PR!
 
 * [Auth0 FGA](https://fga.dev/)
+* [Twintag](https://twintag.com)


### PR DESCRIPTION
We've been running OpenFGA in production for more than a month now, so seems fitting we add our name to the list (as suggested here: https://github.com/openfga/openfga/pull/462#issuecomment-1413854371)
