### PR TITLE
Add Wolt to the list of users

### DIFF
--- a/ADOPTERS.MD
+++ b/ADOPTERS.MD
@@ -9,3 +9,4 @@ Below is a list of projects that have adopted OpenFGA. If you have been using Op
 * [Mapped](https://www.mapped.com/)
 * [Procure Ai](https://www.procure.ai/)
 * [Canonical](https://ubuntu.com/)
+* [Wolt](https://wolt.com/)


### PR DESCRIPTION
As per @aaguiarz request, this adds Wolt to the list of OpenFGA users.

## Description
Adds Wolt to the list of users after getting internal approval for it.

## References


## Review Checklist
- [X] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [X] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [X] The correct base branch is being used, if not `main`
- [X] I have added tests to validate that the change in functionality is working as expected
