### PR TITLE
Add Read.ai to adopters

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -11,3 +11,4 @@ Below is a list of projects that have adopted OpenFGA. If you have been using Op
 * [Canonical](https://ubuntu.com/)
 * [Wolt](https://wolt.com/)
 * [Italarchivi](https://www.italarchivi.it/)
+* [Read AI](https://www.read.ai/)


### PR DESCRIPTION
## Description
Add Read.ai to the adopters list. We're running openfga in production.

## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
