### PR TITLE
fix: missing project links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Navigate to the [brand-assets folder](https://github.com/openfga/community/tree/
 - [Apache APISIX Plugin Authorization OpenFGA for FGA](https://github.com/embesozzi/apisix-authz-openfga)
 - [Zuplo OpenFGA Demo](https://github.com/zuplo-samples/openfga-demo)
 - [OpenFGA Webhook Authorizer for Kubernetes](https://github.com/jon-whit/openfga-authorizer)
-- Tuple editor
+- [OpenFGA Tuple Manager](https://github.com/paulosuzart/fgamanager)
 
 ### Operations
 
@@ -67,7 +67,7 @@ Navigate to the [brand-assets folder](https://github.com/openfga/community/tree/
 - [OpenFGA CLI](https://github.com/ArcticGizmo/fga-cli) -> [OpenFGA CLI](https://github.com/openfga/cli)
 - [Unofficial OpenFGA CLI](https://github.com/rhamzeh/openfga-cli) -> [OpenFGA CLI](https://github.com/openfga/cli)
 - [OpenFGA Kotlin SDK](https://github.com/Ozee-io/fga-kotlin-sdk) -> [OpenFGA Java SDK](https://github.com/openfga/java-sdk)
-- [IntelliJ Integration](https://github.com/le-yams/openfga4intellij) -> 
+- [IntelliJ Integration](https://github.com/le-yams/openfga4intellij) -> [OpenFGA IntelliJ Plugin](https://github.com/openfga/intellij-plugin)
 
 ## Community Meetings
 


### PR DESCRIPTION
Added link to FGA tuple manager and updated deprecations with the IntelliJ link

<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
