### PR TITLE
docs: add contributor ladder file

### DIFF
--- a/CONTRIBUTOR_LADDER.md
+++ b/CONTRIBUTOR_LADDER.md
@@ -1,0 +1,88 @@
+# OpenFGA Contributor Ladder
+
+The OpenFGA project is dedicated to fostering an open and welcoming environment. We believe a diverse and active community is one of the project's core strengths. This contributor ladder outlines the different roles within the OpenFGA community and the path to progress through them. The goal is to provide a clear framework for how one can grow with the project, take on more responsibility, and be recognized for their contributions.
+
+For more details on project governance, please see the [GOVERNANCE.md](https://github.com/openfga/.github/blob/main/GOVERNANCE.md).
+
+## Community Roles
+
+All members of the community are expected to abide by the CNCF's [Code of Conduct](https://github.com/cncf/foundation/blob/main/code-of-conduct.md).
+
+### User
+
+Users are community members who have a need for the project. They are an important part of the community, and their feedback is crucial for the project's success. Anyone can be a user; there are no special requirements.
+
+Common user activities include:
+* Using OpenFGA in their projects.
+* Engaging with the community on platforms like GitHub, Slack, and community calls.
+* Providing feedback on features, performance, and documentation.
+* Reporting bugs and suggesting improvements.
+
+### Contributor
+
+A Contributor is anyone who makes a tangible contribution to the project. Contributors are valued members of the community who invest their time and effort to improve OpenFGA.
+
+Contributions can take many forms, including:
+* **Code**: Submitting pull requests for bug fixes, new features, or improvements to the core OpenFGA repository or its SDKs.
+* **Documentation**: Creating or improving documentation, tutorials, and examples.
+* **Community Support**: Answering questions in the community channels, helping other users, and participating in discussions.
+* **Advocacy**: Writing blog posts, giving talks, or otherwise promoting the project.
+
+**How to become a Contributor:**
+Start by following the guidelines in our [CONTRIBUTING.md](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) file. Find an open issue, or propose a new one, and submit a pull request. The maintainers will work with you to get your contribution merged.
+
+### Member
+
+Members are established contributors who have shown a commitment to the project. This role grants additional permissions, allowing members to have a more direct impact on the project, including contributing to project repos without having to fork first.
+
+**Responsibilities:**
+* Actively participating in community discussions.
+* Reviewing pull requests from other contributors.
+* Triaging issues.
+* Being a positive and welcoming presence in the community.
+
+**Requirements:**
+* A history of several substantive contributions.
+* Active participation in community channels (Slack, GitHub discussions).
+* Nomination by a project Maintainer and no objections from other Maintainers.
+
+**How to become a Member:**
+Members are invited to join the OpenFGA GitHub organization by the Maintainers on request after demonstrating a consistent pattern of valuable contributions and community involvement.
+
+### Maintainer
+
+Maintainers are responsible for the overall health and technical direction of the OpenFGA project. They are experienced contributors who have demonstrated a deep understanding of the project and a commitment to its success. Maintainers are required to have a deep understanding of the project and are highly encouraged to be end-users to gain insight beyond their core competency.
+
+Maintainers can have different areas of responsibilities, such as:
+* Core Server
+* Algorithm & API
+* SDKs & Tooling
+* Docs
+* Project & Release Management
+* Security
+
+The maintainer onboarding is a gradual one. Initially, individuals may be given the ability to merge PRs after approval to a limited set of repos. They can then be added as code owners on those repos, and their area of influence can grow as they get added to more repos.
+
+**Responsibilities:**
+* Reviewing and merging pull requests.
+* Guiding the technical direction of the project.
+* Mentoring new contributors and Members.
+* Ensuring the project follows CNCF guidelines and best practices.
+* Participating in release planning and execution.
+* Making decisions via consensus, as outlined in the project's governance.
+
+**Requirements:**
+* Must be a community Member.
+* **Sustained Contributions:** A long-term history of significant and high-quality contributions.
+* **Technical Expertise:** A deep understanding of the OpenFGA architecture, codebase, and the broader authorization landscape. While some maintainers' expertise may be focused on a particular area while others are broader, all are expected to understand the project, the problem it is solving, how it is doing that and it's direction.
+* **Community Trust:** Demonstrated ability to work collaboratively and make decisions in the best interest of the project.
+
+**How to become a Maintainer:**
+As per the [GOVERNANCE.md](https://github.com/openfga/.github/blob/main/GOVERNANCE.md), any community member can nominate a candidate to become a Maintainer. The nomination is then discussed and approved by the existing Maintainers after reaching a consensus.
+
+**Current Maintainers:**
+You can find a list of the existing maintainers and their areas of expertise in the [MAINTAINERS](https://github.com/openfga/community/blob/main/MAINTAINERS.md) file.
+
+## Moving Up the Ladder
+
+Growth within the OpenFGA community is a natural process that comes from continued involvement and contribution. The project leadership is committed to helping contributors grow and advance. If you have any questions about the contributor ladder or how you can get more involved, please reach out on the community channels. We are here to help you on your journey.


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description

This adds a contributor ladder, somewhat inspired by [CNCF's sample contributor ladder](https://github.com/cncf/project-template/blob/main/CONTRIBUTOR_LADDER.md) to make it easier to understand how one can be part of the OpenFGA project and how they can grow within it.

<!-- Provide a detailed description of the changes -->
#### What problem is being solved?

#### How is it being solved?

#### What changes are made to solve it?

## References
<!--
Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..). We prefer an accompanying issue for all non-trivial PRs.

When referencing links, follow these examples:
* closes https://github.com/openfga/{repo}/issues/{issue_number}
* reverts https://github.com/openfga/{repo}/pull/{pr_number}
* followup https://github.com/openfga/{repo}/pull/{pr_number}
* blocked by https://github.com/openfga/{repo}/pull/{pr_number}
-->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected

