### PR TITLE
Replace Stacklok cloud instance with Custcodian

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -23,7 +23,7 @@ These companies and projects are using OpenFGA in production.  If your company i
 | [Configu](https://configu.com/) | Configu uses OpenFGA to provide organization administrators with advanced access control. By assigning roles and attributes to members, administrators ensure precise and secure access to configurations, tailored to each user’s specific responsibilities and needs. |
 | [Fianu Labs](https://fianu.io/) |  |
 | [ExcID](https://www.excid.io) | ExcID is developing access control solutions for data sharing leveraging OpenFGA. Particularly, multiple instances of OpenFGA are used for storing the relationships among data sources, as well as among data consumers. At the time of access control decision, appropriate relationships are combined. This is achieved using technologies such as W3C Verifiable Credentials and OAuth 2.0 token exchange. ExcID has combined OpenFGA with open-source user management systems and Policy Enforcement Points (PEPs). |
-| [Minder](https://mindersec.github.io/) | [Minder](https://github.com/mindersec/minder/) uses OpenFGA to store hierarchical user->project permissions.  This is also used by [Stacklok](https://stacklok.com/)'s cloud service to store user access. |
+| [Minder](https://mindersec.github.io/) | [Minder](https://github.com/mindersec/minder/) uses OpenFGA to store hierarchical user->project permissions.  This is also used by [Custcodian](https://custcodian.dev/hosted/)'s cloud service to store user access. |
 | [Eiwa](https://eiwa.ag/) |  |
 | [Moss](https://getmoss.com/) |  |
 | [Agicap](https://agicap.com/) |  |
@@ -61,4 +61,4 @@ These companies offer services and assistance implementing solutions with OpenFG
 - GoDaddy: [Fine-grained authorization with OpenFGA and OAuth](https://www.godaddy.com/engineering/2023/12/12/authorization-oauth-openfga/)
 - Configu: [Authorization Over Configurations using OpenFGA](https://configu.com/blog/authorization-over-configurations-using-openfga/)
 - ExcID: [Relation-based access control using Verifiable Credentials](https://medium.com/@excid/relation-based-access-control-using-verifiable-credentials-d8e542a0ce1)
-- Stacklok Minder: [Using OpenFGA to build a relationship-based authorization model in Minder](https://stacklok.com/blog/using-openfga-to-build-a-relationship-based-authorization-model-in-minder)
+- Stacklok: [Implementing multi-tenant relationship-based authorization with OpenFGA](https://www.youtube.com/watch?v=zIJOBLbaZOc) (video)


### PR DESCRIPTION
Stacklok retired their Minder instance in May 2025; Custcodian LLC was formed to provide a new instance to support free Minder usage.  Stacklok has also retired their previous blog.

## Description

Updates some adopter links based on changes since Stacklok's pivot to MCP / AI services.

#### What problem is being solved?

Adopter content was out of date.

#### How is it being solved?

Linked to new adopter, updated blog link to YouTube presentation about similar content.

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`

