### PR TITLE
docs: add ofga (community CLI & TUI) to the tools list

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Navigate to the [brand-assets folder](https://github.com/openfga/community/tree/
 | [OpenFGA Tuple Manager](https://github.com/paulosuzart/fgamanager) | Tool |
 | [Tuna - Tuple Generator for OpenFGA](https://github.com/aberforth4/tuna) | Tool |
 | [Postman Collection](https://github.com/guillempuche/postman_openfga) | Tool |
+| [ofga - an alternative CLI & TUI for OpenFGA](https://github.com/sergiught/openfga-cli) | Tool |
 
 
 ### AI Tooling that helps with OpenFGA implementation


### PR DESCRIPTION
Adds `ofga`, a community-built CLI and TUI for OpenFGA, to the "SDKs, Libraries and Tools" list.

## Description

#### What problem is being solved?

The community projects list has no entry for a terminal-based client. `ofga` is an independent, community-maintained CLI + full-screen TUI for working with OpenFGA stores, authorization models, tuples and queries, and it may be useful to others in the community.

#### How is it being solved?

By adding a single row to the "SDKs, Libraries and Tools" table.

#### What changes are made to solve it?

One line added to `README.md`:

| [ofga - an alternative CLI & TUI for OpenFGA](https://github.com/sergiught/openfga-cli) | Tool |

A note on naming, since it sits close to the official CLI: this project is **not** affiliated with or endorsed by OpenFGA, and is not a fork of [openfga/cli](https://github.com/openfga/cli). It is a separate, independent implementation distributed as `ofga` (the official CLI's binary is `fga`), and it says so in its README. Happy to reword the entry however maintainers prefer if the current wording is not clear enough about that distinction.

Some context on the project:

- MIT licensed, public, with tagged releases and install paths for Homebrew, Docker/GHCR, and `go install`.
- Scriptable CLI with consistent JSON/YAML output and meaningful exit codes, plus an interactive TUI for browsing stores, visualizing the model relation graph, editing tuples and expanding query resolution trees.
- Works against any OpenFGA-compatible server, with connection profiles for switching environments.
- Documentation: https://sergiught.github.io/openfga-cli/

## References

N/A - documentation-only addition to the community project list.

## Review Checklist

- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev)
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected - N/A, documentation-only change.
