### PR TITLE
docs: add June and August 2026 OpenFGA in Action past presentations

### DIFF
--- a/openfga-in-action.md
+++ b/openfga-in-action.md
@@ -16,7 +16,6 @@ If you want to present, please add yourself to the list.
 | 2026-12-10  |                 |           |
 | 2027-01-14  |                 |           |
 
-
 ### Past Presentations
 
 | Date       | Company/Project                               | Presenter                                                       | Content                                              |


### PR DESCRIPTION
Adds past presentation entries for the June and August 2026 community meetings, and extends the future slots through January 2027.

- 2026-06-11: Jose Szychowski (Datum)
- 2026-08-13: Leah Einhorn (Kepler)